### PR TITLE
Add line search result type

### DIFF
--- a/classes/SearchService.php
+++ b/classes/SearchService.php
@@ -156,6 +156,7 @@ class SearchService
                     $lines = DatabaseHelper::getFirstLines($result['fragment_id']);
                     
                     $this->results[] = [
+                        'type' => 'line',
                         'id' => $result['poem_id'],
                         'title' => $result['poem_title'] . ($result['fragment_label'] ? ' - ' . $result['fragment_label'] : ''),
                         'author' => $result['author'] ?? 'Неизвестный автор',

--- a/search.js
+++ b/search.js
@@ -139,9 +139,22 @@ document.addEventListener('DOMContentLoaded', function() {
                 const meta = [
                     item.author && `Автор: <span class="font-medium">${item.author}</span>`
                 ].filter(Boolean).join(' • ');
-                
+
                 html += renderCard(
                     item.poem_title || 'Без названия',
+                    meta,
+                    renderLines(item.lines, 3),
+                    'line'
+                );
+
+            } else if (item.type === 'line') {
+                const meta = [
+                    item.author && `Автор: <span class="font-medium">${item.author}</span>`,
+                    item.year && `Год: <span class="font-medium">${item.year}</span>`
+                ].filter(Boolean).join(' • ');
+
+                html += renderCard(
+                    item.title || 'Без названия',
                     meta,
                     renderLines(item.lines, 3),
                     'line'


### PR DESCRIPTION
## Summary
- mark line search results with type `line`
- display search results that have `type: 'line'`

## Testing
- `php -l classes/SearchService.php`
- `node -c search.js`


------
https://chatgpt.com/codex/tasks/task_e_68751a2e29a08320b21d715040393bbb