### PR TITLE
Fix comments for DatabaseHelper::getFirstLines

### DIFF
--- a/classes/DatabaseHelper.php
+++ b/classes/DatabaseHelper.php
@@ -246,7 +246,7 @@ class DatabaseHelper
         $stmt->execute([$fragmentId, $limit]);
         $lines = $stmt->fetchAll(PDO::FETCH_COLUMN);
         
-        // Всегда возвращаем массив из 2 элементов
-                return array_pad($lines, 2, '');
+        // Возвращаем массив длиной $limit (дополняется пустыми строками при необходимости)
+                return array_pad($lines, $limit, '');
     }
 }


### PR DESCRIPTION
## Summary
- correct doc comment for `getFirstLines`
- pad returned lines array using provided `$limit`

## Testing
- `php -l classes/DatabaseHelper.php`
- `find classes -name '*.php' -print0 | xargs -0 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68751a3583788320aa09b60f4924c740